### PR TITLE
Fix typescript build error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "importHelpers": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
Building the example project was causing the following error:
```
node_modules/@polkadot/api/promise/decorateMethod.d.ts:11:62 - error TS2344: Type 'ObsInnerType<ReturnType<M>>' does not satisfy the constraint 'Codec'.
  Type '{}' is missing the following properties from type 'Codec': encodedLength, hash, isEmpty, registry, and 6 more.

11 export declare function toPromiseMethod<M extends DecorateFn<ObsInnerType<ReturnType<M>>>>(method: M, options?: DecorateMethodOptions): StorageEntryPromiseOverloads;
                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

This seems to be related to the polkadotjs lib.

Skipping the lib check solves the issue.

