### PR TITLE
update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "author": "SubQuery Network",
   "license": "MIT",
   "devDependencies": {
-    "@polkadot/api": "^6",
+    "@polkadot/api": "^7.12.1",
     "@subql/types": "latest",
-    "typescript": "^4.1.3",
+    "typescript": "4.3.2",
     "@subql/cli": "latest",
     "moonbeam-types-bundle": "^2.0.3"
   },


### PR DESCRIPTION
This PR updates the package.json, in particular the polkadot/api and ts versions. These changes enable `npm run build` to work as expected. Yarn works with these changes as well.

Previous error:
<img width="895" alt="Screen Shot 2022-03-17 at 4 49 10 PM" src="https://user-images.githubusercontent.com/26533957/158893537-cb4605fc-8e72-4eca-9cf3-555c8547a68b.png">

Now `npm run build` works:
<img width="344" alt="Screen Shot 2022-03-17 at 4 52 17 PM" src="https://user-images.githubusercontent.com/26533957/158893593-41d55ca2-c5ea-465e-896f-e7f2bae10a8e.png">
